### PR TITLE
Update .devcontainer Node version to 12 (LTS)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Install NodeJS and Yarn.
-RUN curl -sSL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sSL https://deb.nodesource.com/setup_12.x | bash - \
  && curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update -y \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,5 @@
     "workspaceMount": "src=${localWorkspaceFolder},dst=/home/devcontainer-user/project,type=bind",
     "workspaceFolder": "/home/devcontainer-user/project",
     "postCreateCommand": ".devcontainer/post-create.sh",
-    "extensions": [
-        "gruntfuggly.todo-tree"
-    ]
+    "extensions": []
 }


### PR DESCRIPTION
Changelog:
- Update `.devcontainer/Dockerfile` to install Node version 12 (LTS) instead of 10.

This closes #4.