### PR TITLE
fix: install.sh failed when using bash v3 (which is default in macOS 10.15-)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The easiest way to use JXAX is to install it into your `PATH` using our `install
 downloads the `jxax` CLI and extract it into your `usr/local/bin`:
 
 ```bash
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/deskp/jxax/master/scripts/install.sh)"
+$ /bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/deskp/jxax/master/scripts/install.sh)"
 ```
 
 ## Usage

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 # Get latest release from GitHub.
 # See: https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c.


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

`install.sh` failed when `bash` v3 is used.

- **What is the new behavior (if this is a feature change)?**

Use `zsh` instead of `bash`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

- **Other information**:
